### PR TITLE
Remove version from readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ following in your build.sbt:
 
 ```scala
 resolvers += Resolver.bintrayRepo("meetup", "maven")
-libraryDependencies += "com.meetup" %% "scala-logger" % "0.2.13"
+libraryDependencies += "com.meetup" %% "scala-logger" % "X.X.X"
 ```
 See the "Download" badge above to determine the latest released version.
 


### PR DESCRIPTION
This kind of thing only goes out of date (it already has).  Some repos do manual versioning and they are able to update it but we can't since we're true CDeployment.  It's better to just not have it so people will look up the latest version vs accidentally using an older one.