### PR TITLE
tweaking filtering to add missing WARNs

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -8,7 +8,7 @@ log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=net.logstash.log4j.JSONEventLayoutV1
 log4j.appender.stdout.filter.filter1=org.apache.log4j.varia.LevelRangeFilter
 log4j.appender.stdout.filter.filter1.levelMin=TRACE
-log4j.appender.stdout.filter.filter1.levelMax=INFO
+log4j.appender.stdout.filter.filter1.levelMax=WARN
 
 # Directly log messages ERROR... to stderr
 log4j.appender.stderr = org.apache.log4j.ConsoleAppender

--- a/src/test/scala/com/meetup/logging/LoggingTest.scala
+++ b/src/test/scala/com/meetup/logging/LoggingTest.scala
@@ -8,6 +8,7 @@ class LoggingTest extends FunSpec {
     def test() = {
       log.info("Logging a message")
       log.debug("Logging a debug message")
+      log.warn("Logging a warn message")
 
       metric.time("mystat.subkey") {
         log.info("I'm timing this log statement.")


### PR DESCRIPTION
In the course of working on an unrelated project, I noticed that WARN were not logged.  

The cause is that the stdout appender is filtering from TRACE to INFO, instead of TRACE to WARN.  (The comment suggests it _wants_ to filter from TRACE to WARN, but the filter itself only went from TRACE to INFO.)

(I didn't test this in this project because I don't know how.  However, I can confirm that I debugged this with a different log4j.properties file, based on this one, in a different project.)