### PR TITLE
Support for custom metric tags

### DIFF
--- a/src/main/scala/com/meetup/logging/Logging.scala
+++ b/src/main/scala/com/meetup/logging/Logging.scala
@@ -1,9 +1,9 @@
 package com.meetup.logging
 
-import com.meetup.logging.metric.MetricLogger
+import com.meetup.logging.metric.{MetricFormatter, MetricLogger}
 import org.apache.log4j.{Logger => Log4jLogger}
 
 trait Logging {
   protected val log = new Logger(Log4jLogger.getLogger(getClass.getName))
-  protected val metric = new MetricLogger(log.info)
+  protected val metric = new MetricLogger(log.info, MetricFormatter)
 }

--- a/src/main/scala/com/meetup/logging/metric/MetricFormatter.scala
+++ b/src/main/scala/com/meetup/logging/metric/MetricFormatter.scala
@@ -1,8 +1,23 @@
 package com.meetup.logging.metric
 
-object MetricFormatter {
+import net.minidev.json.JSONObject
+
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+
+trait MetricFormatter {
   private val invalidCharacters = "[^a-zA-Z0-9._]+"
 
+  /**
+   * Strips unsupported characters from a metric key.
+   *
+   * Supported characters are alpha chars, numbers, period and underscore. One the first pass each unsupported character
+   * is replaced by a period. On the second pass consecutive periods are squashed into one, also periods are removed
+   * from the beginning and the end of the key. If after these transformations the key becomes an empty string, `None`
+   * is returned. Otherwise the cleaned key is returned.
+   *
+   * @param key a metric key
+   * @return the cleaned key if its non-empty or `None` if the key was cleaned down to nil
+   */
   def cleanKey(key: String): Option[String] = {
     val noInvalidChars = key.replaceAll(invalidCharacters, ".")
     val noExtraPeriods = noInvalidChars.replaceAll("\\.+", ".")
@@ -14,10 +29,50 @@ object MetricFormatter {
     else Some(noPeriodRight)
   }
 
-  def apply(metric: Metric, key: String, value: String): Option[String] = {
-    cleanKey(key).map { cleanedKey =>
-      s"metric.${metric.name}.$cleanedKey=$value"
-    }
+  /**
+   * Strips unsupported characters from metric tags.
+   *
+   * Supported characters are alpha chars, numbers, period and underscore. Each tag's name and value is cleaned from
+   * unsupported characters with [[com.meetup.logging.metric.MetricFormatter#cleanKey cleanKey]]. If the above produces
+   * an empty result for either name or value, such tag is not included into the output. Cleaned tags are converted into
+   * JSON object string where keys are tags names and values are tags values. If there are no valid tags after cleaning,
+   * the method returns `None`
+   *
+   * @param tags metric tags
+   * @return a JSON string of cleaned tag names to cleaned tag values
+   * @example `{"name1":"value1","name2":"value2"}`
+   */
+  def cleanTags(tags: Map[String, String]): Option[String] = {
+    val cleanedTags = for {
+      (name, value) <- tags
+      cleanedName <- cleanKey(name)
+      cleanedValue <- cleanKey(value)
+    } yield (cleanedName, cleanedValue)
+
+    if (cleanedTags.nonEmpty) {
+      val tagsObject = new JSONObject(cleanedTags.asJava)
+      Some(tagsObject.toString)
+    } else None
   }
 
+  /**
+   * Applies the formatter to the metric parameters and produces a metric string.
+   *
+   * @param metric a metric type
+   * @param key    a metric key
+   * @param value  a metric value
+   * @param tags   metric tags (e.g. `"bucket" -> "api"`)
+   * @return a formatted metric string or `None` if the metric parameters are invalid
+   */
+  def apply(metric: Metric, key: String, value: String, tags: Map[String, String]): Option[String]
+}
+
+object MetricFormatter extends MetricFormatter {
+  override def apply(metric: Metric, key: String, value: String, tags: Map[String, String]): Option[String] = {
+    cleanKey(key).map { cleanedKey =>
+      val cleanedTags = cleanTags(tags).map("#" + _).getOrElse("")
+
+      s"metric.${metric.name}.$cleanedKey=$value$cleanedTags"
+    }
+  }
 }

--- a/src/test/scala/com/meetup/logging/metric/MetricFormatterTest.scala
+++ b/src/test/scala/com/meetup/logging/metric/MetricFormatterTest.scala
@@ -1,12 +1,13 @@
 package com.meetup.logging.metric
 
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{FunSpec, Matchers}
 
-class MetricFormatterTest extends FunSpec with Matchers {
+class MetricFormatterTest extends FunSpec with Matchers with TableDrivenPropertyChecks {
 
   describe("cleaning a key") {
 
-      def test(in: String, out: String) = {
+      def test(in: String, out: String): Unit = {
         MetricFormatter.cleanKey(in) shouldBe Some(out)
       }
 
@@ -75,6 +76,72 @@ class MetricFormatterTest extends FunSpec with Matchers {
 
     it("should fail if empty") {
       MetricFormatter.cleanKey("") shouldBe None
+    }
+  }
+
+  describe("cleaning tags") {
+    it("should return an empty result if there are no tags") {
+      MetricFormatter.cleanTags(Map.empty) shouldBe empty
+    }
+
+    it("should return a json string of cleaned tag names to cleaned tag values") {
+      MetricFormatter.cleanTags(Map("key1" -> "value1", "key2" -> "value2")) shouldBe
+        Some("""{"key1":"value1","key2":"value2"}""")
+    }
+
+    it("should skip tags with invalid names") {
+      MetricFormatter.cleanTags(Map("key1" -> "value1", "$+%." -> "value2")) shouldBe
+        Some("""{"key1":"value1"}""")
+    }
+
+    it("should skip tags with invalid values") {
+      MetricFormatter.cleanTags(Map("key1" -> "#+=@", "key2" -> "value2")) shouldBe
+        Some("""{"key2":"value2"}""")
+    }
+
+    it("should return an empty result if all tags are invalid") {
+      MetricFormatter.cleanTags(Map("key1" -> "#+=@", "$+%." -> "value2")) shouldBe empty
+    }
+  }
+
+  describe("formatting a metric") {
+    val metricTypes = Table(
+      "Metric",
+      Count,
+      Gauge,
+      Set,
+      Timing
+    )
+
+    it("should return an empty result if a metric key is invalid") {
+      forAll(metricTypes) { metricType =>
+        MetricFormatter(metricType, "$@-..", "1", Map("bucket" -> "test")) shouldBe empty
+      }
+    }
+
+    describe("without tags") {
+      it("should return a cleaned metric key and original value") {
+        forAll(metricTypes) { metricType =>
+          MetricFormatter(metricType, "my.aw3$0m3.metric.", "foo$bar@baz", Map.empty) shouldBe
+            Some(s"""metric.${metricType.name}.my.aw3.0m3.metric=foo$$bar@baz""")
+        }
+      }
+    }
+
+    describe("with tags") {
+      it("should return a cleaned metric key, orginal value and cleaned tags") {
+        forAll(metricTypes) { metricType =>
+          MetricFormatter(metricType, "my.aw3$0m3.metric.", "foo$bar@baz", Map(".bucket+1" -> "test=2.")) shouldBe
+            Some(s"""metric.${metricType.name}.my.aw3.0m3.metric=foo$$bar@baz#{"bucket.1":"test.2"}""")
+        }
+      }
+
+      it("should not append tags if they are invalid") {
+        forAll(metricTypes) { metricType =>
+          MetricFormatter(metricType, "my.aw3$0m3.metric.", "foo$bar@baz", Map("$+%." -> "#+=@")) shouldBe
+            Some(s"""metric.${metricType.name}.my.aw3.0m3.metric=foo$$bar@baz""")
+        }
+      }
     }
   }
 }

--- a/src/test/scala/com/meetup/logging/metric/MetricLoggerTest.scala
+++ b/src/test/scala/com/meetup/logging/metric/MetricLoggerTest.scala
@@ -1,0 +1,125 @@
+package com.meetup.logging.metric
+
+import org.scalatest.{FunSpec, Matchers}
+
+class MetricLoggerTest extends FunSpec with Matchers {
+  import MetricLoggerTest._
+
+  private val ShouldBeLog: String => ((=> String) => Unit) = expected =>
+    actual => actual shouldBe expected
+
+  private val ShouldMatchRegexLog: String => ((=> String) => Unit) = rg =>
+    actual => actual should fullyMatch regex rg
+
+  private val Key = "test_key"
+
+  describe("incr") {
+    it("should log a counter incremented by 1 by default with no tags") {
+      val logger = createLogger(ShouldBeLog(s"metric.count.$Key=1"))
+      logger.incr(Key)
+    }
+
+    it("should log a counter incremented by the given value with no tags") {
+      val logger = createLogger(ShouldBeLog(s"metric.count.$Key=42"))
+      logger.incr(Key, 42)
+    }
+
+    it("should log a counter incremented by the given value with the given tags") {
+      val logger = createLogger(ShouldBeLog(s"""metric.count.$Key=42#{"foo":"bar"}"""))
+      logger.incr(Key, 42, Map("foo" -> "bar"))
+    }
+  }
+
+  describe("decr") {
+    it("should log a counter decremented by 1 by default with no tags") {
+      val logger = createLogger(ShouldBeLog(s"metric.count.$Key=-1"))
+      logger.decr(Key)
+    }
+
+    it("should log a counter decremented by the given value with no tags") {
+      val logger = createLogger(ShouldBeLog(s"metric.count.$Key=-42"))
+      logger.decr(Key, 42)
+    }
+
+    it("should log a counter decremented by the given value with the given tags") {
+      val logger = createLogger(ShouldBeLog(s"""metric.count.$Key=-42#{"foo":"bar"}"""))
+      logger.decr(Key, 42, Map("foo" -> "bar"))
+    }
+  }
+
+  describe("gauge") {
+    it("should log a gauge with the given value with no tags") {
+      val logger = createLogger(ShouldBeLog(s"metric.gauge.$Key=42"))
+      logger.gauge(Key, 42)
+    }
+
+    it("should log a gauge with the given value with tags") {
+      val logger = createLogger(ShouldBeLog(s"""metric.gauge.$Key=42#{"foo":"bar"}"""))
+      logger.gauge(Key, 42, Map("foo" -> "bar"))
+    }
+  }
+
+  describe("set") {
+    it("should log a set with the given value with no tags") {
+      val logger = createLogger(ShouldBeLog(s"metric.set.$Key=42"))
+      logger.set(Key, 42)
+    }
+
+    it("should log a set with the given value with tags") {
+      val logger = createLogger(ShouldBeLog(s"""metric.set.$Key=42#{"foo":"bar"}"""))
+      logger.set(Key, 42, Map("foo" -> "bar"))
+    }
+  }
+
+  describe("timing") {
+    it("should log a timing with the given value with no tags") {
+      val logger = createLogger(ShouldBeLog(s"metric.timing.$Key=42"))
+      logger.timing(Key, 42)
+    }
+
+    it("should log a timing with the given value with tags") {
+      val logger = createLogger(ShouldBeLog(s"""metric.timing.$Key=42#{"foo":"bar"}"""))
+      logger.timing(Key, 42, Map("foo" -> "bar"))
+    }
+  }
+
+  describe("time") {
+    it("should log a timing for the given code block with no tags") {
+      // Regex to match timing value, allowing difference up to 99 milliseconds
+      val logger = createLogger(ShouldMatchRegexLog(s"""^metric\\.timing\\.$Key=1[0-9][0-9]$$"""))
+      logger.time(Key) {
+        Thread.sleep(100L)
+      }
+    }
+
+    it("should log a timing for the given code block with tags") {
+      // Regex to match timing value, allowing difference up to 99 milliseconds
+      val logger = createLogger(ShouldMatchRegexLog(s"""^metric\\.timing\\.$Key=1[0-9][0-9]#\\{"foo":"bar"\\}$$"""))
+      logger.time(Key, Map("foo" -> "bar")) {
+        Thread.sleep(100L)
+      }
+    }
+  }
+
+  it("allows plugging in a custom metric formatter") {
+    val logger = createLogger(ShouldBeLog("test"), TestMetricFormatter)
+    logger.incr(Key)
+    logger.decr(Key)
+    logger.gauge(Key, 42)
+    logger.set(Key, 42)
+    logger.timing(Key, 42)
+    logger.time(Key) {
+      Thread.sleep(100L)
+    }
+  }
+}
+
+object MetricLoggerTest {
+  private object TestMetricFormatter extends MetricFormatter {
+    override def apply(metric: Metric, key: String, value: String, tags: Map[String, String]): Option[String] =
+      Some("test")
+  }
+
+  private def createLogger(log: (=> String) => Unit, metricFormatter: MetricFormatter = MetricFormatter): MetricLogger =
+    new MetricLogger(log, metricFormatter)
+}


### PR DESCRIPTION
#### Why?
Sometimes it's useful to add custom tags to metrics (for example, assign a bucket to a metric). The current metric logger doesn't support this, so people have to write their own implementations atop of the logger.

#### What?
Added an optional map of tags to each method of `MetricLogger`. Tags are stripped of unsupported characters and converted to JSON map string that is appended to the formatted metric.

`MetricFormatter` was converted to a trait that contains helper methods for cleaning metric keys and tags and defines an abstract `apply` method that should be implemented by formatters. The original `MetricFormatter` object became the default implementation of the formatter. `MetricLogger` was updated to take `MetricFormatter` as a constructor argument. All these changes allow users to easily customize metrics format to suit their needs. 

#### How did I test it?
Added unit tests for `MetricLogger` and new helper methods of `MetricFormatter`. Added new cases to tests for the default `MetricFormatter` implementation. Built the project with `sbt clean package test` and `make package`, and made sure that all tests passed and the build succeeded.