### PR TITLE
Safely handle null keys/values in metrics tags

### DIFF
--- a/src/main/scala/com/meetup/logging/metric/MetricFormatter.scala
+++ b/src/main/scala/com/meetup/logging/metric/MetricFormatter.scala
@@ -19,7 +19,9 @@ trait MetricFormatter {
    * @return the cleaned key if its non-empty or `None` if the key was cleaned down to nil
    */
   def cleanKey(key: String): Option[String] = {
-    val noInvalidChars = key.replaceAll(invalidCharacters, ".")
+    val safeKey = Option(key).getOrElse("")
+
+    val noInvalidChars = safeKey.replaceAll(invalidCharacters, ".")
     val noExtraPeriods = noInvalidChars.replaceAll("\\.+", ".")
 
     val noPeriodLeft = noExtraPeriods.replaceAll("^\\.+", "")

--- a/src/test/scala/com/meetup/logging/metric/MetricFormatterTest.scala
+++ b/src/test/scala/com/meetup/logging/metric/MetricFormatterTest.scala
@@ -77,6 +77,10 @@ class MetricFormatterTest extends FunSpec with Matchers with TableDrivenProperty
     it("should fail if empty") {
       MetricFormatter.cleanKey("") shouldBe None
     }
+
+    it("should fail if null") {
+      MetricFormatter.cleanKey(null) shouldBe None
+    }
   }
 
   describe("cleaning tags") {
@@ -95,7 +99,7 @@ class MetricFormatterTest extends FunSpec with Matchers with TableDrivenProperty
     }
 
     it("should skip tags with invalid values") {
-      MetricFormatter.cleanTags(Map("key1" -> "#+=@", "key2" -> "value2")) shouldBe
+      MetricFormatter.cleanTags(Map("key1" -> "#+=@", "key2" -> "value2", "key3test" -> null)) shouldBe
         Some("""{"key2":"value2"}""")
     }
 


### PR DESCRIPTION
In the [payments-tax](https://github.com/meetup/payments-tax) service we accidentally passed  `null` to a metrics tag value and it raised a `NullPointerException`.

The value was coming from a `Throwable` exception which happened to have no message (e.g. tag `"reason" -> exception.getMessage` where `exception.getMessage = null`).

This PR prevents `NullPointerException` from being thrown if any of the key/value of a metrics tag is `null`.