### PR TITLE
Publish jar compatible with Scala 2.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CI_WORKDIR ?= $(shell pwd)
 
 TARGET ?= __package-sbt
 
-VERSION ?= 0.2.$(CI_BUILD_NUMBER)
+VERSION ?= 0.3.$(CI_BUILD_NUMBER)
 BUILDER_TAG = "meetup/sbt-builder:0.1.3"
 
 help:
@@ -36,11 +36,11 @@ __package-sbt:
 		coverageReport \
 		coverallsMaybe \
 		coverageOff \
-		publishLocal \
+		+publishLocal \
 		component:test
 
 __publish-sbt: __package-sbt
-	sbt publish cleanLocal
+	sbt +publish cleanLocal
 
 __set-publish:
 	$(eval TARGET=__publish-sbt)

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
   "net.logstash.log4j" % "jsonevent-layout" % "1.7",
 
   // Override scalatest and scalacheck versions in CommonSettingsPlugin to versions that are compatible with scala 2.12
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test,component,it",
+  "org.scalatest" %% "scalatest" % "3.0.8",
   "org.scalacheck" %% "scalacheck" % "1.12.6" % "test,component,it"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,16 @@
 enablePlugins(CommonSettingsPlugin)
 enablePlugins(CoverallsWrapper)
 
+crossScalaVersions := Seq("2.11.8", "2.12.2")
+
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.21",
   "org.slf4j" % "slf4j-log4j12" % "1.7.21",
-  "net.logstash.log4j" % "jsonevent-layout" % "1.7"
+  "net.logstash.log4j" % "jsonevent-layout" % "1.7",
+
+  // Override scalatest and scalacheck versions in CommonSettingsPlugin to versions that are compatible with scala 2.12
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test,component,it",
+  "org.scalacheck" %% "scalacheck" % "1.12.6" % "test,component,it"
 )
 
 name := "scala-logger"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.18

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,3 +8,6 @@ addSbtPlugin("com.meetup" % "sbt-plugins" % "0.2.17")
 addSbtPlugin("com.eed3si9n" % "sbt-dirty-money" % "0.1.0")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+
+// not sure where the original scoverage is coming from? does this override any defined above?
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,5 +9,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-dirty-money" % "0.1.0")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
-// not sure where the original scoverage is coming from? does this override any defined above?
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")


### PR DESCRIPTION
scala-logger is a dependency for the event-logger library (https://github.com/meetup/event-logger/blob/master/build.sbt#L9). ML needs a version of event-logger that is compatible with Scala 2.12, so that means we also need a 2.12 compatible version of this library. 